### PR TITLE
Disable verbose and causes for error type.

### DIFF
--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -21,7 +21,6 @@
 package zapcore
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -46,17 +45,21 @@ func encodeError(key string, err error, enc ObjectEncoder) error {
 	basic := err.Error()
 	enc.AddString(key, basic)
 
-	switch e := err.(type) {
-	case errorGroup:
-		return enc.AddArray(key+"Causes", errArray(e.Errors()))
-	case fmt.Formatter:
-		verbose := fmt.Sprintf("%+v", e)
-		if verbose != basic {
-			// This is a rich error type, like those produced by
-			// github.com/pkg/errors.
-			enc.AddString(key+"Verbose", verbose)
-		}
-	}
+	/*
+		We currently disable printing verbose errors and their causes.
+		We experienced errors to be others too vast in terms of their context. Especially since the causes and the
+		basic error string err.Error() are essentially duplicates.
+		switch e := err.(type) {
+		case errorGroup:
+			return enc.AddArray(key+"Causes", errArray(e.Errors()))
+		case fmt.Formatter:
+			verbose := fmt.Sprintf("%+v", e)
+			if verbose != basic {
+				// This is a rich error type, like those produced by
+				// github.com/pkg/errors.
+				enc.AddString(key+"Verbose", verbose)
+			}
+		}*/
 	return nil
 }
 

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -47,7 +47,7 @@ func encodeError(key string, err error, enc ObjectEncoder) error {
 
 	/*
 		We currently disable printing verbose errors and their causes.
-		We experienced errors to be others too vast in terms of their context. Especially since the causes and the
+		We experienced errors to be otherwise too vast in terms of their context. Especially since the causes and the
 		basic error string err.Error() are essentially duplicates.
 		switch e := err.(type) {
 		case errorGroup:


### PR DESCRIPTION
Enabled structured logging which includes using `zap.Error` but this leads to rather ugly errors being printed with questionable value:
```log
reprocessor: 2023/08/22 20:36:14.786027 reprocessor.go:312: Error: Error enriching image {"image": "gke.gcr.io/gke-metrics-agent-windows:1.9.3-gke.2@sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8", "error": "image enrichment error: error getting metadata for image: gke.gcr.io/gke-metrics-agent-windows:1.9.3-gke.2@sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8 error: getting metadata from registry: \"Public GKE GCR\": could not find manifest in list for architecture linux:amd64: 'sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8'", "errorCauses": [{"error": "error getting metadata for image: gke.gcr.io/gke-metrics-agent-windows:1.9.3-gke.2@sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8 error: getting metadata from registry: \"Public GKE GCR\": could not find manifest in list for architecture linux:amd64: 'sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8'", "errorCauses": [{"error": "getting metadata from registry: \"Public GKE GCR\": could not find manifest in list for architecture linux:amd64: 'sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8'", "errorVerbose": "could not find manifest in list for architecture linux:amd64: 'sha256:c17c0590d061e266bccb6afe619d2c4f5c8d5050daf4db23385d251e178315a8'\ngetting metadata from registry: \"Public GKE GCR\"\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichImageWithRegistry\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:433\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichWithMetadata\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:350\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:221\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).enrichImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:513\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:307\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImagesAndResyncDeployments.func1\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:366\nruntime.goexit\n\truntime/asm_amd64.s:1598"}]}]}
```